### PR TITLE
Add Minecraft 26.1 build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,17 +14,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew :impl-paper:build
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     `kotlin-dsl`
-    kotlin("jvm") version "1.9.0"
-    kotlin("plugin.serialization") version "2.1.0"
+    kotlin("jvm") version "2.3.0"
+    kotlin("plugin.serialization") version "2.3.0"
 }
 
 repositories {
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     fun pluginDep(id: String, version: String) = "${id}:${id}.gradle.plugin:${version}"
-    val kotlinVersion = "2.1.0"
+    val kotlinVersion = "2.3.0"
 
     compileOnly(kotlin("gradle-plugin", kotlinVersion))
     runtimeOnly(kotlin("gradle-plugin", kotlinVersion))
@@ -25,17 +25,17 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.+")
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
 
-    // Fabric implementation
-    implementation("net.fabricmc:fabric-loom:1.8-SNAPSHOT")
-    implementation(pluginDep("io.github.juuxel.loom-quiltflower", "1.9.0"))
+    // Fabric implementation (disabled: Loom expects Java 17, blocks the Paper build on 26.1)
+    // implementation("net.fabricmc:fabric-loom:1.8-SNAPSHOT")
+    // implementation(pluginDep("io.github.juuxel.loom-quiltflower", "1.9.0"))
 
     // Paper implementation
-    implementation(pluginDep("io.papermc.paperweight.userdev", "2.0.0-beta.19"))
+    implementation(pluginDep("io.papermc.paperweight.userdev", "2.0.0-beta.21"))
     implementation(pluginDep("xyz.jpenilla.run-paper", "3.0.0"))
 
     implementation(pluginDep("com.gradleup.shadow", "9.2.2"))
     implementation(pluginDep("com.modrinth.minotaur", "2.+"))
 }
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }

--- a/buildSrc/src/main/kotlin/fabric-script.gradle.kts
+++ b/buildSrc/src/main/kotlin/fabric-script.gradle.kts
@@ -1,3 +1,8 @@
+// Fabric build path disabled. Uses Loom, which expects a Java 17 toolchain. It appears
+// that fabric support is already disabled anyway in settings.gradle.kts.
+// To add Fabric support in the future, uncomment the body below, readd loom in 
+// buildSrc/build.gradle.kts, and update for 26.1.
+/*
 plugins {
     id("fabric-loom")
     id("io.github.juuxel.loom-quiltflower")
@@ -48,3 +53,4 @@ tasks {
         }
     }
 }
+*/

--- a/buildSrc/src/main/kotlin/kotlin-script.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-script.gradle.kts
@@ -22,16 +22,25 @@ dependencies {
 tasks {
     compileJava {
         options.encoding = "UTF-8"
-        options.release.set(21)
+        options.release.set(25)
     }
     compileKotlin {
-        compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
+        compilerOptions.jvmTarget.set(JvmTarget.JVM_25)
     }
 }
 
 java {
     toolchain { 
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
+configurations.named("compileClasspath") {
+    attributes {
+        attribute(
+            org.gradle.api.attributes.java.TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE,
+            25
+        )
     }
 }
 

--- a/buildSrc/src/main/kotlin/paper-script.gradle.kts
+++ b/buildSrc/src/main/kotlin/paper-script.gradle.kts
@@ -10,19 +10,16 @@ repositories {
 }
 
 dependencies {
-    paperweight.paperDevBundle("1.21.11-R0.1-SNAPSHOT")
+    paperweight.paperDevBundle("26.1.2.build.+")
     compileOnly("de.miraculixx:kpaper:1.2.1")
-    compileOnly("dev.jorel:commandapi-paper-core:11.0.0")
-    implementation("dev.jorel:commandapi-kotlin-paper:11.1.0")
-    implementation("dev.jorel:commandapi-kotlin-core:11.1.0")
-    implementation("dev.jorel:commandapi-paper-shade:11.1.0")
-
-
-
+    compileOnly("dev.jorel:commandapi-paper-core:11.2.0")
+    implementation("dev.jorel:commandapi-kotlin-paper:11.2.0")
+    implementation("dev.jorel:commandapi-kotlin-core:11.2.0")
+    implementation("dev.jorel:commandapi-paper-shade:11.2.0")
 }
 
-tasks {
-    assemble {
-        dependsOn(reobfJar)
+paperweight {
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }

--- a/gradle/gradle-daemon-jvm.properties
+++ b/gradle/gradle-daemon-jvm.properties
@@ -9,4 +9,4 @@ toolchainUrl.UNIX.AARCH64=https\://api.foojay.io/disco/v3.0/ids/fd88a209e0f18ca6
 toolchainUrl.UNIX.X86_64=https\://api.foojay.io/disco/v3.0/ids/1543f336911ae3d7d37bedec8b74d98c/redirect
 toolchainUrl.WINDOWS.AARCH64=https\://api.foojay.io/disco/v3.0/ids/3087f28f30be41ab6818c16a488f5f8a/redirect
 toolchainUrl.WINDOWS.X86_64=https\://api.foojay.io/disco/v3.0/ids/638dfeab250dbbb0639b82816307982e/redirect
-toolchainVersion=21
+toolchainVersion=25

--- a/impl-paper/src/main/resources/plugin.yml
+++ b/impl-paper/src/main/resources/plugin.yml
@@ -5,17 +5,17 @@ description: "A BlueMap addition plugin. Give your players the option to place m
 author: Miraculixx
 website: https://miraculixx.de
 load: STARTUP
-api-version: 1.13
+api-version: 26.1
 depend:
   - "BlueMap"
 libraries:
-  - "org.jetbrains.kotlin:kotlin-stdlib:2.1.0"
+  - "org.jetbrains.kotlin:kotlin-stdlib:2.3.0"
   - "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
   - "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4"
   - "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
-  - "dev.jorel:commandapi-paper-shade:11.0.0"
-  - "dev.jorel:commandapi-kotlin-paper:11.0.0"
-  - "dev.jorel:commandapi-kotlin-core:11.0.0"
+  - "dev.jorel:commandapi-paper-shade:11.2.0"
+  - "dev.jorel:commandapi-kotlin-paper:11.2.0"
+  - "dev.jorel:commandapi-kotlin-core:11.2.0"
   - "de.miraculixx:kpaper:1.2.1"
 
 commands:


### PR DESCRIPTION
Updates the paper build to compile on MC version 26.1. Built and tested on a 26.1.2 server, and things load and banner markers seem to work.

Mostly just updated versions for dependencies, but ran into an issue with Fabric/Loom expecting a Java 17, which caused build issues. Since Fabric already seems disabled, I went ahead and disabled that build path config. Otherwise:
- For paper:
    - Updated paperDevBundle to 26.1.2.build.+
    - Set api-version to 26.1
    - Removed jar obfuscation reofbJar task hook
- Updated java toolchain to 25 (JVM targets, gradle daemon JVM, paperweight.javaLauncher)
- Added compileClasspath JVM attribute to fix paper API for Java 25
- Updated Kotlin to 2.3.0
- Updated CommandAPI to 11.2.0
- Updated paperweight-userdev to 2.0.0-beta.21